### PR TITLE
package.json: specify the files to include in the npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "coveralls": "3.0.2",
     "standard": "12.0.1",
     "tap": "12.0.1"
-  }
+  },
+  "files": [
+    "lib/*.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
```
C:\Users\xmr\Desktop\html-validator>npm pack --dry
npm notice
npm notice package: html-validator@3.1.2
npm notice === Tarball Contents ===
npm notice 1.3kB package.json
npm notice 1.5kB index.js
npm notice 1.1kB LICENSE
npm notice 5.4kB README.md
npm notice 809B  lib/config.js
npm notice 572B  lib/filter-data.js
npm notice === Tarball Details ===
npm notice name:          html-validator
npm notice version:       3.1.2
npm notice filename:      html-validator-3.1.2.tgz
npm notice package size:  3.5 kB
npm notice unpacked size: 10.6 kB
npm notice shasum:        1dc4954f5fb37a7f27a32e21dd6e9274f5aa046e
npm notice integrity:     sha512-KXK6ZR3ObOHuA[...]eKGqvIlGXMeig==
npm notice total files:   6
npm notice
html-validator-3.1.2.tgz
```